### PR TITLE
Update contribs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ A massive thank you goes out to all these wonderful people ([emoji key][emoji]):
 [apache2]: https://www.apache.org/licenses/LICENSE-2.0
 [call]: https://meetings-eu1.hubspot.com/matt2/customer-demos
 [careers]: https://openline.ai
-[contributions]: https://github.com/openline-ai/community/blob/main/README.md
+[contributions]: https://github.com/openline-ai/openline.ai/blob/otter/docs/contribute/index.md
 [docs]: https://openline.ai
 [emoji]: https://allcontributors.org/docs/en/emoji-key
 [oasis-repo]: https://github.com/openline-ai/openline-customer-os/


### PR DESCRIPTION
The current contributions link seems dead (or pointing to a private).  Proposing an assumed valid replacement at https://github.com/openline-ai/openline.ai/blob/otter/docs/contribute/index.md

## Proposed changes

Describe the big picture of your changes here.  If it fixes a bug or resolves a feature request, be sure to link that issue!

## Changes

What types of changes does your code introduce?  _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes
- [x] Documentation Update (if none of the other choices apply)
- [x] Other (please describe below)

Does this change impact front end code?

- [x] No
- [ ] Yes (please include screenshots or Figma files)


## Checklist

- [ ] Code compiles correctly
- [ ] I have added tests that prove my fix is effective, or that my feature works
- [ ] Unit tests pass locally with my changes
- [ ] I have added/updated all necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules


## Additional context

Just a link update, no impact expected.